### PR TITLE
Support TweetDeck

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -46,6 +46,7 @@
 			<key>Allowed Domains</key>
 			<array>
 				<string>twitter.com</string>
+				<string>*.twitter.com</string>
 			</array>
 			<key>Include Secure Pages</key>
 			<true/>

--- a/Scripts/injected.js
+++ b/Scripts/injected.js
@@ -4,34 +4,31 @@ var observer = new MutationObserver(function(mutations) {
 
 function replaceLinks() {
     var links = document.querySelectorAll(".tweet-text a");
-    for (i in links) {
+    for (var i = 0; i < links.length; i++) {
         var link = links[i];
-        if (link && link.getAttribute) {
-            var expandedURL = link.getAttribute('data-expanded-url');
-            if (expandedURL) {
-                links[i].href = expandedURL
-            }
+        var expandedURL;
+        if ((expandedURL = link.getAttribute('data-expanded-url'))) {
+            link.href = expandedURL;
+        } else if ((expandedURL = link.getAttribute('data-full-url'))) {
+            link.href = expandedURL;
         }
     }
 }
 
 var interval = setInterval(function() {
     replaceLinks()
-}, 25)
+}, 25);
 
 document.addEventListener("DOMContentLoaded", function(e) {
     clearInterval(interval);
 
     replaceLinks();
 
-    var target = document.querySelector(".stream-items");
-    if (target !== null) {
-        observer.observe(target, {
-            childList: true,
-            subtree: false,
-            attributes: false,
-            characterData: false
-        });
-    }
+    observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: false,
+        characterData: false
+    });
 });
 


### PR DESCRIPTION
I tried to add `tweetdeck.twitter.com` to Allowed Domains, but it didn't work on Safari 9.0.3.
